### PR TITLE
Add login screen using users table

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ Tela principal aonde é possível visualizar os produtos cadastrados, criar novo
 3. Crie um arquivo `.env` na raiz, e copie o conteúdo do arquivo `.env.example` para ele
 4. Configure a URL do banco de dados no arquivo `.env`
 5. Execute o projeto
+6. Faça login com o usuário padrão `admin` e senha `admin`
 
 ## Dependências 
 - Java 21

--- a/scripts/script.sql
+++ b/scripts/script.sql
@@ -4,3 +4,11 @@ CREATE TABLE product (
     price_in_cents INT NOT NULL,
     quantity INT NOT NULL
 );
+
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL
+);
+
+INSERT INTO users (username, password) VALUES ('admin', '8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918');

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,7 +1,9 @@
 import javax.swing.*;
 import services.ProductService;
+import services.UserService;
 import util.Database;
 import view.MainFrame;
+import view.LoginFrame;
 import view.Theme;
 
 public class Main {
@@ -10,9 +12,15 @@ public class Main {
             Theme.apply();
             
             Database db = new Database();
-            
+            UserService us = new UserService(db);
+
+            LoginFrame login = new LoginFrame(us);
+            login.setVisible(true);
+            if (!login.isAuthenticated()) {
+                return;
+            }
+
             ProductService ps = new ProductService(db);
-            
             MainFrame frame = new MainFrame(ps);
             frame.setVisible(true);
         });

--- a/src/model/UserModel.java
+++ b/src/model/UserModel.java
@@ -1,0 +1,31 @@
+package model;
+
+public class UserModel {
+    private int id;
+    private String username;
+    private String password;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/services/UserService.java
+++ b/src/services/UserService.java
@@ -1,0 +1,65 @@
+package services;
+
+import model.UserModel;
+import util.Database;
+import util.HashUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class UserService {
+    private final Database db;
+
+    public UserService(Database db) {
+        this.db = db;
+    }
+
+    public boolean authenticate(String username, String password) {
+        String query = "SELECT password FROM users WHERE username = ?";
+        try (Connection conn = db.getConnection();
+             PreparedStatement ps = conn.prepareStatement(query)) {
+            ps.setString(1, username);
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) {
+                String stored = rs.getString("password");
+                return stored.equals(HashUtil.sha256(password));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao autenticar usuário", e);
+        }
+        return false;
+    }
+
+    public void create(String username, String password) {
+        String query = "INSERT INTO users (username, password) VALUES (?, ?)";
+        try (Connection conn = db.getConnection();
+             PreparedStatement ps = conn.prepareStatement(query)) {
+            ps.setString(1, username);
+            ps.setString(2, HashUtil.sha256(password));
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao criar usuário", e);
+        }
+    }
+
+    public UserModel getByUsername(String username) {
+        String query = "SELECT * FROM users WHERE username = ?";
+        try (Connection conn = db.getConnection();
+             PreparedStatement ps = conn.prepareStatement(query)) {
+            ps.setString(1, username);
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) {
+                UserModel user = new UserModel();
+                user.setId(rs.getInt("id"));
+                user.setUsername(rs.getString("username"));
+                user.setPassword(rs.getString("password"));
+                return user;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao buscar usuário", e);
+        }
+        return null;
+    }
+}

--- a/src/util/HashUtil.java
+++ b/src/util/HashUtil.java
@@ -1,0 +1,21 @@
+package util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class HashUtil {
+    public static String sha256(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 algorithm not found", e);
+        }
+    }
+}

--- a/src/view/LoginFrame.java
+++ b/src/view/LoginFrame.java
@@ -1,0 +1,58 @@
+package view;
+
+import services.UserService;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class LoginFrame extends JFrame {
+    private final UserService userService;
+    private final JTextField userField = new JTextField(15);
+    private final JPasswordField passField = new JPasswordField(15);
+    private boolean authenticated = false;
+
+    public LoginFrame(UserService userService) {
+        super("Login");
+        this.userService = userService;
+        initializeComponents();
+    }
+
+    private void initializeComponents() {
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setSize(300, 180);
+        setLocationRelativeTo(null);
+        setResizable(false);
+        setLayout(new BorderLayout());
+
+        JPanel form = new JPanel(new GridLayout(2, 2, 10, 10));
+        form.setBorder(Theme.WINDOW_PADDING);
+        form.add(new JLabel("Usuário:"));
+        form.add(userField);
+        form.add(new JLabel("Senha:"));
+        form.add(passField);
+        add(form, BorderLayout.CENTER);
+
+        JPanel buttons = new JPanel();
+        JButton loginButton = new JButton("Entrar");
+        JButton cancelButton = new JButton("Cancelar");
+        buttons.add(loginButton);
+        buttons.add(cancelButton);
+        add(buttons, BorderLayout.SOUTH);
+
+        loginButton.addActionListener(e -> {
+            String user = userField.getText().trim();
+            String pass = new String(passField.getPassword());
+            if (userService.authenticate(user, pass)) {
+                authenticated = true;
+                dispose();
+            } else {
+                JOptionPane.showMessageDialog(this, "Credenciais inválidas.", "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        });
+        cancelButton.addActionListener(e -> System.exit(0));
+    }
+
+    public boolean isAuthenticated() {
+        return authenticated;
+    }
+}


### PR DESCRIPTION
## Summary
- add users table and default admin credentials to setup script
- implement SHA-256 helper for password hashing
- add `UserModel` and `UserService`
- create a Swing login screen
- update entry point to authenticate before showing product management window
- document login step in README

## Testing
- `javac -cp "lib/*:" -d out $(find src -name "*.java")`
- `java -cp "lib/*:out" Main` *(fails: Could not find /.env)*

------
https://chatgpt.com/codex/tasks/task_e_684b4935676083289f8a7ede06f6e8fe